### PR TITLE
feat(jellystore, subject): use sync.Map for safe work with map

### DIFF
--- a/internal/pkg/jellystore/load.go
+++ b/internal/pkg/jellystore/load.go
@@ -76,10 +76,6 @@ const (
 )
 
 func (s *Store) loadByFile(key string) (err error) {
-	if s.mpstate == nil {
-		return nil
-	}
-
 	// usable path by db data
 	pdata := fmt.Sprintf("%s/%s/%s", s.config.Path, key, logFileName)
 
@@ -113,11 +109,10 @@ func (s *Store) loadByFile(key string) (err error) {
 	for {
 		bb := make([]byte, maxMessageSize+messageLen)
 		_, err = dataFile.ReadAt(bb, iteration)
+		if errors.Is(err, io.EOF) {
+			break
+		}
 		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-
 			return errors.Wrapf(err, "read messages by key %s from path %s", key, pdata)
 		}
 

--- a/internal/pkg/jellystore/subject.go
+++ b/internal/pkg/jellystore/subject.go
@@ -1,0 +1,51 @@
+package jellystore
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type subject struct {
+	sync.Map
+}
+
+func (s *subject) load(key string) (*message, error) {
+	val, ok := s.Load(key)
+	if !ok {
+		return nil, errors.Errorf("value by %s not found", key)
+	}
+
+	m, ok := val.(*message)
+	if !ok {
+		return nil, errors.Errorf("fatal type assertion to message %[1]T %+[1]v", val)
+	}
+
+	return m, nil
+}
+
+func (s *subject) srange(f func(key string, value *message) error) (err error) {
+	s.Range(func(key, value any) bool {
+		kk, _ := key.(string)
+		vv, _ := value.(*message)
+		if err = f(kk, vv); err != nil {
+			return false
+		}
+
+		return true
+	})
+
+	return err
+}
+
+func (s *subject) store(key string) *message {
+	val, ok := s.Load(key)
+	if ok {
+		m, _ := val.(*message)
+		return m
+	}
+
+	mm := newMessage()
+	s.Store(key, mm)
+	return mm
+}


### PR DESCRIPTION
Remove unsafe mpstate map, use sync.Map for safe work. Add new file subjects when implement usable work.

Thanks: Maxim Biryukov (https://github.com/biryukovmaxim).